### PR TITLE
Clarify pkg is not ROS-Industrial specific

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ CMake Boilerplate Scripts
 =========================
 This contains a collection of boilerplate CMake scripts and marcos.
 
+Note: this package is *not* specific to ROS-Industrial and is usable with any package which uses CMake. The prefix was added to facilitate releasing this into different ROS distributions.
+
 .. contents:: Table of Contents
    :depth: 3
 


### PR DESCRIPTION
As per subject.

Thought this was good to add, as fi with `industrial_ci` we always get the question whether it's usable "outside ROS-Industrial".
