### PR TITLE
Add ENABLE functionality to initialize_code_coverage

### DIFF
--- a/ros_industrial_cmake_boilerplate/cmake/code_coverage.cmake
+++ b/ros_industrial_cmake_boilerplate/cmake/code_coverage.cmake
@@ -91,7 +91,10 @@ set(CMAKE_COVERAGE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/ccov)
 
 # Common initialization/checks
 macro(initialize_code_coverage)
-  if(NOT CODE_COVERAGE_ADDED)
+  set(oneValueArgs ENABLE)
+  cmake_parse_arguments(initialize_code_coverage "" "${oneValueArgs}" "" ${ARGN})
+
+  if(NOT CODE_COVERAGE_ADDED AND ((NOT DEFINED initialize_code_coverage_ENABLE) OR (initialize_code_coverage_ENABLE)))
     set(CODE_COVERAGE_ADDED ON)
 
     # Common Targets


### PR DESCRIPTION
This function was missing the ENABLE functionality so it can be enabled and disabled.