### PR TITLE
Replace underscores with dashes in component names for CPack

### DIFF
--- a/cmake/cpack_tools.cmake
+++ b/cmake/cpack_tools.cmake
@@ -250,8 +250,14 @@ macro(cpack_component)
             PACKAGE_NAME
             ${PROJECT_NAME})
 
-  string(TOUPPER ${ARG_COMPONENT} COMPONENT_UPPER)
-  string(TOLOWER ${ARG_COMPONENT} COMPONENT_LOWER)
+  string(
+    REPLACE "_"
+            "-"
+            COMPONENT_NAME
+            ${ARG_COMPONENT})
+
+  string(TOUPPER ${COMPONENT_NAME} COMPONENT_UPPER)
+  string(TOLOWER ${COMPONENT_NAME} COMPONENT_LOWER)
 
   if(UNIX)
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")


### PR DESCRIPTION
Currently, the `cpack_component` macro does not replace underscores in component names with dashes, as it does with the project name. So, for example the component `trajopt_ifopt` in the project `tesseract_motion_planners` gets resolved to `tesseract-motion-planners-trajopt_ifopt` instead of `tesseract-motion-planners-trajopt-ifopt`. This PR makes the required change to fix this issue.

Addresses [this comment](https://github.com/tesseract-robotics/tesseract_planning/pull/577/files#r1911367438)